### PR TITLE
Watch, upload and transform

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/scripts/ignored/

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /scripts/ignored/
+/files

--- a/README.md
+++ b/README.md
@@ -43,3 +43,60 @@ runs
        ... 
     ...
 ```
+
+
+## Helper scripts
+
+
+### 1. Automatic syncing of files from a client machine (where data is produced) to the server (where data is consumed):
+
+ - On the client machine: open `./scripts/watch-client` and adjust these variables:
+
+    ```bash
+    # Directory to watch. Files That appear in this directory will be sent.
+    WATCH_DIR="/some/absolute/client/path/"
+    # or
+    WATCH_DIR="${THIS_DIR}/../some/relative/client/path/"
+
+    # Username on the server. The SSH session will be established for this user.
+    SERVER_USERNAME="ubuntu"
+
+    # Directory on the server to which the files will be placed
+    SERVER_DIR="/home/${SERVER_USERNAME}/files"
+
+    # Server IP address or hostname
+    SERVER_ADDRESS="18.158.45.194"
+    ```
+
+ - On the client machine: send SSH key to the server, so that SSH sessions could be established without password
+
+    ```bash
+    ssh-copy-id username@12.34.56.78
+    ```
+
+ - On the client machine: Run `./scripts/watch-client`
+
+ - On the server machine: list files on the server by issuing an ls command every 0.5 seconds:
+
+    ```bash
+    watch -ctn 0.5 -- ls -alhR /the/server/directory
+    ```
+
+ - On the client machine: Go to watch directory (defined as `${WATCH_DIR}`) and make a 0-size file:
+
+    ```bash
+    touch empty.txt
+    ```
+
+ - On the server machine: Note that the file appeared on the server and is listed by the `ls` command, having size 0
+
+ - On the client machine: Go to watch directory (defined as `${WATCH_DIR}`) and make a 0-size file:
+
+    ```bash
+    fallocate -l 1G files/aaa/11.txt
+    ```
+
+- On the server machine: Note that the file appeared on the server, and is listed by the `ls` command, has a random suffix in the filename and with size growing until filly downloaded. After that the file is renamed to the original name.
+
+
+

--- a/README.md
+++ b/README.md
@@ -96,7 +96,17 @@ runs
     fallocate -l 1G files/aaa/11.txt
     ```
 
-- On the server machine: Note that the file appeared on the server, and is listed by the `ls` command, has a random suffix in the filename and with size growing until filly downloaded. After that the file is renamed to the original name.
+ - On the server machine: Note that the file appeared on the server, and is listed by the `ls` command, has a random suffix in the filename and with size growing until filly downloaded. After that the file is renamed to the original name.
 
 
+### 2. Watch files in a directory (on server machine) and run a command when a file changes:
 
+ - Modify `${WATCH_DIR}` in `./scripts/watch-server` to point to the directory that should be watched
+
+ - On the server machine: Run `./scripts/watch-server`
+
+ - On the server machine: Go to watch directory (defined as `${WATCH_DIR}` in the script) and create some files with `touch` and `fallocate` as described above.
+
+ - Note that these modifications are printed by the `./scripts/watch-server`  script.
+
+ - Modify the bash command at the bottom of the `./scripts/watch-server` to run any required command instead of (ar additional to) `echo` and using the variables provided by `watchexec`, e.g. `./my-awesome-command --input=${WATCHEXEC_CREATED_PATH}"`. The newly created files should now trigger that command and the  `${WATCHEXEC_CREATED_PATH}` will be substituted by the path of the created file.

--- a/scripts/install-dependencies
+++ b/scripts/install-dependencies
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+#
+# Installs dependencies:
+#
+#  1. watchexec
+#     https://watchexec.github.io/
+#
+
+set -euo pipefail
+
+# Directory where this script resides.
+THIS_DIR=$(dirname "$(readlink -f "$0")")
+
+# Directory where to put the `watchexec` executable
+DST_DIR="${THIS_DIR}/ignored"
+
+WATCHEXEC_VERSION="1.17.1"
+WATCHEXEC_URL="https://github.com/watchexec/watchexec/releases/download/cli-v${WATCHEXEC_VERSION}/watchexec-${WATCHEXEC_VERSION}-x86_64-unknown-linux-musl.tar.xz"
+
+# Create destination directory if not exists
+mkdir -p "${DST_DIR}"
+
+if [ ! -f "${DST_DIR}/watchexec" ]; then
+  echo "Installing watchexec"
+
+  # Download and extract `watchexec` executable into the destination directory
+  curl -fsSL "${WATCHEXEC_URL}" |
+    tar -C "${DST_DIR}" -xJ --strip-components=1 "watchexec-1.17.1-x86_64-unknown-linux-musl/watchexec"
+fi

--- a/scripts/watch-client
+++ b/scripts/watch-client
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+#
+# Client script that watches files in a directory and sends newly created
+# and updated files to the server.
+#
+
+set -euo pipefail
+
+# Directory where this script resides.
+THIS_DIR=$(dirname "$(readlink -f "$0")")
+
+bash "${THIS_DIR}/install-dependencies"
+
+# Directory to watch. Files That appear in this directory will be sent.
+WATCH_DIR="${THIS_DIR}/../files/"
+
+# Username on the server. The SSH session will be established for this user.
+SERVER_USERNAME="ubuntu"
+
+# Server directory to which the files will be placed
+SERVER_DIR="/home/${SERVER_USERNAME}/files"
+
+# Server IP address or hostname
+SERVER_ADDRESS="18.158.45.194"
+
+# Create watch directory if not already exist
+mkdir -p "${WATCH_DIR}/"
+
+# Watch files with the specified extenstions in the watch directory using
+# `watchexec` and upon changes (new files created or existing files modified)
+# run `rsync` to copy files via SSH to the server.
+"${THIS_DIR}/dependencies/watchexec" \
+  --notify \
+  --watch="${WATCH_DIR}" \
+  --shell="bash" \
+  --restart \
+  -- \
+  rsync --out-format="%n" \
+  --archive \
+  --recursive \
+  --compress \
+  --no-owner \
+  --no-group \
+  --exclude="./" \
+  "${WATCH_DIR}/" \
+  ${SERVER_USERNAME}@${SERVER_ADDRESS}:${SERVER_DIR}

--- a/scripts/watch-client
+++ b/scripts/watch-client
@@ -29,7 +29,7 @@ mkdir -p "${WATCH_DIR}/"
 # Watch files with the specified extenstions in the watch directory using
 # `watchexec` and upon changes (new files created or existing files modified)
 # run `rsync` to copy files via SSH to the server.
-"${THIS_DIR}/dependencies/watchexec" \
+"${THIS_DIR}/ignored/watchexec" \
   --notify \
   --watch="${WATCH_DIR}" \
   --shell="bash" \

--- a/scripts/watch-server
+++ b/scripts/watch-server
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+#
+# Server script that watches files in a directory and runs a command to
+# transform files
+
+set -euo pipefail
+
+# Directory where this script resides.
+THIS_DIR=$(dirname "$(readlink -f "$0")")
+
+bash "${THIS_DIR}/install-dependencies"
+
+# Directory to watch. Files That appear in this directory will be sent.
+WATCH_DIR="${THIS_DIR}/../files/"
+
+# Create watch directory if not already exist
+mkdir -p "${WATCH_DIR}/"
+
+# Watch files with the specified extenstions in the watch directory using
+# `watchexec` and upon changes (new files created or existing files modified)
+# run a command.
+# Here the command is a bash script that prints variables provided by the
+# `watchexec`. These variables tell which files were modified and how.
+# This can be used to run a transformato script on these.
+"${THIS_DIR}/ignored/watchexec" \
+  --notify \
+  --watch="${WATCH_DIR}" \
+  --shell="bash" \
+  --restart \
+  -- \
+  bash -c '\
+    echo "updated: ${WATCHEXEC_CREATED_PATH}"
+    echo "removed: ${WATCHEXEC_REMOVED_PATH}"
+    echo "renamed: ${WATCHEXEC_RENAMED_PATH}"
+    echo "modified: ${WATCHEXEC_WRITTEN_PATH}"
+    echo "metadata changed: ${WATCHEXEC_META_CHANGED_PATH}"
+    echo "mutiple files changed under this common path: ${WATCHEXEC_COMMON_PATH}"
+  '


### PR DESCRIPTION
Quick and dirty solution to get the automation going.

Adds:
 - [x] a script to install dependencies (currently only [watchexec](https://watchexec.github.io/)). It runs when needed (currently if watchexec is missing).
 - [x] a script to automatically copy files from a client machine (producer) to a server (consumer)
 - [x] a script to automatically start transforms on the new files on the server side 
 - [x] readme on how to use it all